### PR TITLE
Add version fallback to ingestion

### DIFF
--- a/src/manage.py
+++ b/src/manage.py
@@ -76,10 +76,7 @@ class IngestLibrary(webapp2.RequestHandler):
 
         data = json.loads(response.content)
         if not isinstance(data, object):
-          library.error = 'repo contains no valid version tags'
-          github.release()
-          library.put()
-          return
+          data = []
         data = [d for d in data if versiontag.is_valid(d['ref'][10:])]
         if len(data) is 0:
           library.error = 'repo contains no valid version tags'
@@ -98,7 +95,7 @@ class IngestLibrary(webapp2.RequestHandler):
             continue
           sha = version['object']['sha']
           params = {}
-          if (is_newest):
+          if is_newest:
             params["latestVersion"] = "True"
             is_newest = False
           version_object = Version(parent=library.key, id=tag, sha=sha)

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -4,9 +4,9 @@ import re
 
 from manage import app
 from datamodel import Library, Version, Content
+import json
 import quota
 import util
-import json
 
 from google.appengine.api import urlfetch_stub
 from google.appengine.ext import ndb
@@ -168,7 +168,7 @@ class ManageAddTest(ManageTestBase):
     tasks = self.tasks.get_filtered_tasks()
     self.assertEqual(len(tasks), 0)
 
-    response = self.app.get(util.ingest_version_task('org', 'repo', 'v1.0.1'))
+    self.app.get(util.ingest_version_task('org', 'repo', 'v1.0.1'))
 
     version2 = version2.key.get()
     self.assertEqual(version2.error, "Could not store README.md as a utf-8 string")

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -6,6 +6,7 @@ from manage import app
 from datamodel import Library, Version, Content
 import quota
 import util
+import json
 
 from google.appengine.api import urlfetch_stub
 from google.appengine.ext import ndb
@@ -128,7 +129,7 @@ class ManageAddTest(ManageTestBase):
 
     tasks = self.tasks.get_filtered_tasks()
     self.assertEqual(len(tasks), 2)
-    self.assertEqual(tasks[1].url, util.ingest_version_task('org', 'repo', 'v1.0.0'))
+    self.assertEqual(tasks[1].url, util.ingest_version_task('org', 'repo', 'v1.0.0') + '?latestVersion=True')
 
   def test_ingest_version(self):
     library = Library(id='org/repo', metadata='{"full_name": "NSS Bob", "stargazers_count": 420, "subscribers_count": 419, "forks": 418, "updated_at": "2011-8-10T13:47:12Z"}', contributor_count=417)
@@ -152,6 +153,29 @@ class ManageAddTest(ManageTestBase):
     self.assertEqual(readmeHtml.content, '<html>README</html>')
     bower = ndb.Key(Library, 'org/repo', Version, 'v1.0.0', Content, 'bower').get()
     self.assertEqual(bower.content, '{}')
+
+  def test_ingest_version_falls_back(self):
+    library = Library(id='org/repo', metadata='{"full_name": "NSS Bob", "stargazers_count": 420, "subscribers_count": 419, "forks": 418, "updated_at": "2011-8-10T13:47:12Z"}', contributor_count=417)
+    library.tags = json.dumps(["v1.0.0", "v1.0.1"])
+    library.put()
+    version1 = Version(parent=library.key, id='v1.0.0', sha='lol')
+    version1.put()
+    version2 = Version(parent=library.key, id='v1.0.1', sha='lol')
+    version2.put()
+
+    self.respond_to('https://raw.githubusercontent.com/org/repo/v1.0.1/README.md', chr(248))
+
+    tasks = self.tasks.get_filtered_tasks()
+    self.assertEqual(len(tasks), 0)
+
+    response = self.app.get(util.ingest_version_task('org', 'repo', 'v1.0.1'))
+
+    version2 = version2.key.get()
+    self.assertEqual(version2.error, "Could not store README.md as a utf-8 string")
+
+    tasks = self.tasks.get_filtered_tasks()
+    self.assertEqual(len(tasks), 1)
+    self.assertEqual(tasks[0].url, util.ingest_version_task('org', 'repo', 'v1.0.0') + '?latestVersion=True')
 
 if __name__ == '__main__':
   unittest.main()

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -1,9 +1,9 @@
+import json
+import re
 import unittest
 import webtest
-import re
 
 from datamodel import Library, Version, Content
-import json
 from manage import app
 import quota
 import util

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -2,9 +2,9 @@ import unittest
 import webtest
 import re
 
-from manage import app
 from datamodel import Library, Version, Content
 import json
+from manage import app
 import quota
 import util
 

--- a/src/util.py
+++ b/src/util.py
@@ -64,7 +64,9 @@ def ingest_version_task(owner, repo, version):
 def ingest_dependencies_task(owner, repo, version):
   return '/task/ingest/dependencies/%s/%s/%s' % (owner, repo, version)
 
-def new_task(url, params={}):
+def new_task(url, params=None):
+  if params is None:
+    params = {}
   return taskqueue.add(method='GET', url=url, params=params)
 
 def inline_demo_transform(markdown):

--- a/src/util.py
+++ b/src/util.py
@@ -64,8 +64,8 @@ def ingest_version_task(owner, repo, version):
 def ingest_dependencies_task(owner, repo, version):
   return '/task/ingest/dependencies/%s/%s/%s' % (owner, repo, version)
 
-def new_task(url):
-  return taskqueue.add(method='GET', url=url)
+def new_task(url, params={}):
+  return taskqueue.add(method='GET', url=url, params=params)
 
 def inline_demo_transform(markdown):
   return re.sub(r'<!---?\n*(```(?:html)?\n<custom-element-demo.*?```)\n-->', r'\1', markdown, flags=re.DOTALL)


### PR DESCRIPTION
If the newest library version can't be ingested successfully, fallback on the next-most-recent version so that we have something in the search index.