### PR TITLE
Basic on demand form

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,8 +14,7 @@ module.exports = function (grunt) {
     },
 
     eslint: {
-      target: ['client/src/**/*.html'],
-      target: ['analysis/*.js']
+      target: ['client/src/**/*.html', 'analysis/*.js']
     },
   });
   grunt.loadNpmTasks('grunt-pylint');

--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ To increase Github API quota, acqure a Github token and store it:
 ```bash
 cat > secrets.yaml
 github_token: 'your-github-token'
-^D
+```
+
+If you would like to use reCAPTCHA, obtain a token and store it:
+```bash
+cat > secrets.yaml
+recaptcha: 'your-token'
 ```
 
 Deploy to staging.

--- a/client/README.md
+++ b/client/README.md
@@ -1,7 +1,7 @@
 ## Front-end client
 ### Running
 ```bash
-dev_appserver.py .
+dev_appserver.py client/client.yaml
 ```
 
 Running locally will run against the staging server. To override the backend instance set the instance parameter:
@@ -11,19 +11,17 @@ localhost:8080/element/PolymerElements/app-layout?instance=custom-elements.appsp
 
 ### Testing
 ```bash
-wct --root client
+wct --skip-plugin sauce
 ```
 
 ### Deploying to staging
+Staging is auto deployed on a successful build.
+
+### Deploying to prod
 ```bash
 cd client
 polymer build
 cp client.yaml build/bundled
 appcfg.py update build/bundled/client.yaml
-```
-
-### Deploying to prod
-```bash
-# as above
 appcfg.py update build/bundled/client.yaml -A custom-elements
 ```

--- a/client/src/catalog-add.html
+++ b/client/src/catalog-add.html
@@ -6,7 +6,7 @@
     </style>
 
     <template is="dom-if" if="[[queryParams.code]]">
-      <form action="/api/add" method="post">
+      <form action="[[baseUrls.api]]/api/add" method="post">
         <input type="hidden" name="code" value="[[queryParams.code]]">
         <input type="submit" value="test">
       </form>

--- a/client/src/catalog-app.html
+++ b/client/src/catalog-app.html
@@ -27,6 +27,7 @@
       <catalog-element name="element" route="[[subroute]]" base-urls="[[baseUrls(queryParams)]]"></catalog-element>
       <catalog-search name="search" route="{{subroute}}" base-urls="[[baseUrls(queryParams)]]"></catalog-search>
       <catalog-add name="add" query-params="{{queryParams}}" base-urls="[[baseUrls(queryParams)]]"></catalog-add>
+      <catalog-ondemand name="ondemand" base-urls="[[baseUrls(queryParams)]]"></catalog-ondemand>
     </iron-pages>
   </template>
 

--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -204,7 +204,7 @@
         <div class="scroller">
           <iron-icon icon="search"></iron-icon>
           <input type="search" placeholder="Search" on-tap="_navigateToSearch">
-          <a href="/element/[[routeMatch.owner]]/[[repo]]" id="elementTitle">
+          <a href="/element/[[routeMatch.owner]]/[[repo]][[versionRoute]]" id="elementTitle">
             <div class="menu-item" selected>
               <h2 title>[[routeMatch.owner]] /</h2>
               <h2 title class="repo-title">[[repo]]</h2>
@@ -219,7 +219,7 @@
             <div class="menu-item section-title">Demos</div>
 
             <template is="dom-repeat" items=[[bundledDemos]] as="demo">
-              <a class="menu-item indent" href="/element/[[routeMatch.owner]]/[[repo]]/demo/[[demo.path]]">
+              <a class="menu-item indent" href="/element/[[routeMatch.owner]]/[[repo]][[versionRoute]]/demo/[[demo.path]]">
                 <div>[[demo.desc]]</div>
               </a>
             </template>
@@ -227,12 +227,12 @@
             <div class="menu-item section-title">Docs</div>
 
             <template is="dom-repeat" items="[[bundledElements]]" as="element">
-              <a class="menu-item indent" href="/element/[[routeMatch.owner]]/[[repo]]/[[element.is]]">
+              <a class="menu-item indent" href="/element/[[routeMatch.owner]]/[[repo]][[versionRoute]]/[[element.is]]">
                 <div>[[element.is]]</div>
               </a>
             </template>
             <template is="dom-repeat" items="[[bundledBehaviors]]" as="behavior">
-              <a class="menu-item indent" href="/element/[[routeMatch.owner]]/[[repo]]/[[behavior.is]]">
+              <a class="menu-item indent" href="/element/[[routeMatch.owner]]/[[repo]][[versionRoute]]/[[behavior.is]]">
                 <div>[[behavior.is]]</div>
               </a>
             </template>
@@ -265,7 +265,7 @@
       <!-- TODO(samli): Lacking drawer button -->
       <template is="dom-if" if="[[demo]]">
         <iframe id="demo-frame"
-                src="[[baseUrls.userContent]]/[[routeMatch.owner]]/[[repo]]/[[data.version]]/[[repo]]/[[demo]]">
+                src="[[baseUrls.userContent]]/[[routeMatch.owner]]/[[repo]][[versionRoute]]/[[repo]]/[[demo]]">
         </iframe>
       </template>
 
@@ -348,26 +348,35 @@
         this.bundledBehaviors = [];
       },
 
+      _splitRoute: function() {
+        this.versionRoute = '';
+        this.subElement = null;
+        this.demo = null;
+
+        var split = this.routeTail.path.split('/');
+        split.shift(); // Skip first /
+        this.repo = split.shift();
+
+        if (split.length && split[0].indexOf('.') != -1)
+          this.versionRoute = '/' + split.shift();
+        else if (split.length && split[0].match(/[0-9a-f]{20,}/))
+          this.versionRoute = '/' + split.shift();
+
+        if (split.length && split[0].indexOf('demo') != -1) {
+          split.shift();
+          this.demo = split.join('/');
+          split = [];
+        }
+
+        if (split.length)
+          this.subElement = split.shift();
+      },
+
       _routeChanged: function(route, visible) {
         if (!visible || !this._loaded || route.prefix !== '/element')
           return;
 
-        // Split the URL - /:repo/?version/?[subElement|demo/path]
-        var match = this.routeTail.path.match(
-            // repo $1
-            '^/([^/]+)' +
-            // optional version $2
-            '(?:/(v?\\d+\\.\\d+\\.\\d+))?' +
-            // optional
-            '(?:/' +
-              // 'demo' $3, demo name or sub-element $4
-              '(demo/)?(.*)' +
-            ')?');
-        this.repo = match[1];
-        this.versionRoute = match[2] ? '/' + match[2] : '';
-        this.subElement = (match[3] || !match[4]) ? null : match[4];
-        this.demo = (match[3] && match[4]) ? match[4] : null;
-
+        this._splitRoute();
         document.title = this.routeMatch.owner + '/' + this.repo;
 
         // Generate requests

--- a/client/src/catalog-ondemand.html
+++ b/client/src/catalog-ondemand.html
@@ -1,0 +1,55 @@
+<link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="../bower_components/iron-ajax/iron-ajax.html">
+
+<script src='https://www.google.com/recaptcha/api.js'></script>
+
+<dom-module id="catalog-ondemand">
+  <template>
+    Enter the github URL you want to preview: <input type="text" name="url" value="{{url::input}}">
+    <input type="submit" value="Preview" on-tap="onSubmit">
+
+    <div class="g-recaptcha" data-sitekey="6LcCRSgTAAAAAGhe5bUDS5lVHAPNN2cY7xo-Zk5f"></div>
+
+    <iron-ajax
+      id="ajax"
+      method="POST"
+      url="[[baseUrls.api]]/api/ondemand"
+      handle-as="text"
+      on-response="_taskTriggered"
+      on-error="_error"></iron-ajax>
+
+  </template>
+
+  <script>
+    Polymer({
+
+      is: 'catalog-ondemand',
+
+      properties: {
+        baseUrls: Object,
+
+        _sha: String,
+      },
+
+      onSubmit: function() {
+        if (!grecaptcha || !grecaptcha.getResponse())
+          return;
+
+        this.$.ajax.params = {
+          url: this.url,
+          recaptcha: grecaptcha.getResponse()
+        };
+        this.$.ajax.generateRequest();
+      },
+
+      _taskTriggered: function(event) {
+        window.location = 'element/' + event.detail.response;
+      },
+
+      _error: function() {
+        console.log('An error occured. Please try again.');
+      },
+
+    });
+  </script>
+</dom-module>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "globals": {
       "CustomElements": true,
       "HTMLImports": true,
-      "Polymer": true
+      "Polymer": true,
+      "grecaptcha": true
     },
     "rules": {
       "new-cap": 0,

--- a/src/api.py
+++ b/src/api.py
@@ -5,6 +5,7 @@ from google.appengine.api import urlfetch
 import logging
 import json
 import re
+import urllib
 import webapp2
 import yaml
 
@@ -206,12 +207,13 @@ class GetAccessToken(webapp2.RequestHandler):
     self.response.write(response.content)
 
 def validate_captcha(handler):
-  captcha_response = handler.request.get('captcha_response')
-  response = urlfetch.fetch('https://www.google.com/recaptcha/api/siteverify', payload={
+  recaptcha = handler.request.get('recaptcha')
+  params = {
       'secret': util.SECRETS['recaptcha'],
-      'response': captcha_response,
+      'response': recaptcha,
       'remoteip': handler.request.remote_addr,
-  }, method='POST', validate_certificate=True)
+  }
+  response = urlfetch.fetch('https://www.google.com/recaptcha/api/siteverify', payload=urllib.urlencode(params), method='POST', validate_certificate=True)
   if not json.loads(response.content).get('success', False):
     handler.response.set_status(403)
     return False
@@ -221,6 +223,7 @@ class OnDemand(webapp2.RequestHandler):
   def post(self):
     if not validate_captcha(self):
       return
+
     url = self.request.get('url')
     match = re.match(r'https://github.com/(.*?)/([^/]*)(.*)', url)
     owner = match.group(1)
@@ -230,8 +233,10 @@ class OnDemand(webapp2.RequestHandler):
     # SHA already defined
     match = re.match(r'.*commits?/(.*)', tail)
     if match:
-      self.response.write(match.group(1))
-      util.new_task(util.ingest_commit_task(owner, repo), params={'commit': match.group(1), 'url': url})
+      self.response.headers['Access-Control-Allow-Origin'] = '*'
+      self.response.headers['Content-Type'] = 'application/json'
+      self.response.write('%s/%s/%s' % (owner, repo, match.group(1)))
+      util.new_task(util.ingest_commit_task(owner, repo), params={'commit': match.group(1), 'url': url}, target='manage')
       return
 
     # Resolve SHA using these patterns and Github API
@@ -250,8 +255,10 @@ class OnDemand(webapp2.RequestHandler):
       self.response.write('Error resolving url (%s)', url)
 
     sha = json.loads(response.content)['object']['sha']
-    util.new_task(util.ingest_commit_task(owner, repo), params={'commit': sha, 'url': url})
-    self.response.write(sha)
+    util.new_task(util.ingest_commit_task(owner, repo), params={'commit': sha, 'url': url}, target='manage')
+    self.response.headers['Access-Control-Allow-Origin'] = '*'
+    self.response.headers['Content-Type'] = 'application/json'
+    self.response.write('%s/%s/%s' % (owner, repo, sha))
 
 
 # pylint: disable=invalid-name

--- a/src/api_test.py
+++ b/src/api_test.py
@@ -21,33 +21,33 @@ class OnDemandTest(ApiTestBase):
     self.respond_to('https://api.github.com/repos/org/repo/git/refs/pull/1/head', '{"ref": "refs/pull/1/head", "object": {"sha": "pullsha"}}')
     response = self.app.post('/api/ondemand', params={'url': 'https://github.com/org/repo/pull/1'})
     self.assertEqual(response.status_int, 200)
-    self.assertEqual(response.normal_body, 'pullsha')
+    self.assertEqual(response.normal_body, 'org/repo/pullsha')
 
   def test_resolve_commitsha(self):
     self.respond_to('https://www.google.com/recaptcha/api/siteverify', '{"success": true}')
     response = self.app.post('/api/ondemand', params={'url': 'https://github.com/org/repo/commit/commitsha'})
     self.assertEqual(response.status_int, 200)
-    self.assertEqual(response.normal_body, 'commitsha')
+    self.assertEqual(response.normal_body, 'org/repo/commitsha')
 
   def test_resolve_treebranch(self):
     self.respond_to('https://www.google.com/recaptcha/api/siteverify', '{"success": true}')
     self.respond_to('https://api.github.com/repos/org/repo/git/refs/heads/branch', '{"ref": "refs/heads/branch", "object": {"sha": "branchsha"}}')
     response = self.app.post('/api/ondemand', params={'url': 'https://github.com/org/repo/tree/branch'})
     self.assertEqual(response.status_int, 200)
-    self.assertEqual(response.normal_body, 'branchsha')
+    self.assertEqual(response.normal_body, 'org/repo/branchsha')
 
   def test_resolve_repo(self):
     self.respond_to('https://www.google.com/recaptcha/api/siteverify', '{"success": true}')
     self.respond_to('https://api.github.com/repos/org/repo/git/refs/heads/master', '{"ref": "refs/heads/master", "object": {"sha": "mastersha"}}')
     response = self.app.post('/api/ondemand', params={'url': 'https://github.com/org/repo'})
     self.assertEqual(response.status_int, 200)
-    self.assertEqual(response.normal_body, 'mastersha')
+    self.assertEqual(response.normal_body, 'org/repo/mastersha')
 
   def test_resolve_pullsha(self):
     self.respond_to('https://www.google.com/recaptcha/api/siteverify', '{"success": true}')
     response = self.app.post('/api/ondemand', params={'url': 'https://github.com/org/repo/pull/1/commits/pullcommitsha'})
     self.assertEqual(response.status_int, 200)
-    self.assertEqual(response.normal_body, 'pullcommitsha')
+    self.assertEqual(response.normal_body, 'org/repo/pullcommitsha')
 
 if __name__ == '__main__':
   unittest.main()

--- a/src/datamodel.py
+++ b/src/datamodel.py
@@ -44,7 +44,7 @@ class Library(ndb.Model):
 
   @staticmethod
   def versions_for_key(key):
-    versions = Version.query(ancestor=key).map(lambda v: v.key.id())
+    versions = [v.key.id() for v in Version.query(ancestor=key) if versiontag.is_valid(v.key.id())]
     versions.sort(versiontag.compare)
     return versions
 

--- a/src/manage.py
+++ b/src/manage.py
@@ -200,6 +200,7 @@ class IngestLibraryCommit(LibraryTask):
       version.put()
       task_url = util.ingest_version_task(owner, repo, commit)
       util.new_task(task_url)
+      util.publish_analysis_request(self.owner, self.repo, commit)
       self.commit()
     except RequestAborted:
       pass

--- a/src/user_content.py
+++ b/src/user_content.py
@@ -27,6 +27,8 @@ class GetResource(webapp2.RequestHandler):
 
     config_map = {}
     for dependency in dependencies:
+      if dependency['owner'] == owner and dependency['repo'] == repo:
+        continue
       config_map[dependency['name']] = '%s/%s/%s' % (dependency['owner'], dependency['repo'], dependency['version'])
 
     # Ensure the repo serves its own version.

--- a/src/util.py
+++ b/src/util.py
@@ -14,7 +14,7 @@ GITHUB_TOKEN = None
 try:
   with open('secrets.yaml', 'r') as f:
     SECRETS = yaml.load(f)
-    GITHUB_TOKEN = yaml.load(f).get('github_token', None)
+    GITHUB_TOKEN = SECRETS.get('github_token', None)
 except (OSError, IOError):
   logging.error('No more secrets.')
 
@@ -71,10 +71,10 @@ def ingest_version_task(owner, repo, version):
 def ingest_dependencies_task(owner, repo, version):
   return '/task/ingest/dependencies/%s/%s/%s' % (owner, repo, version)
 
-def new_task(url, params=None):
+def new_task(url, params=None, target=None):
   if params is None:
     params = {}
-  return taskqueue.add(method='GET', url=url, params=params)
+  return taskqueue.add(method='GET', url=url, params=params, target=target)
 
 def inline_demo_transform(markdown):
   return re.sub(r'<!---?\n*(```(?:html)?\n<custom-element-demo.*?```)\n-->', r'\1', markdown, flags=re.DOTALL)


### PR DESCRIPTION
This change adds a front-end for on-demand requests which uses recaptcha to verify a human is requesting to process a Github URL.

Also includes a bunch of fixes:
 * ESLint all files again
 * Always include versions in URLs
 * Update README.md
 * Specify a target for on-demand task
 * Allow SHAs to be used instead of versions on the element page