### PR TITLE
Rework collection references as separate entities

### DIFF
--- a/src/datamodel.py
+++ b/src/datamodel.py
@@ -124,8 +124,6 @@ class Version(ndb.Model):
         existing_version = result_map.get(collection_id, None)
         if existing_version is None or versiontag.compare(collection_version.key.id(), existing_version.key.id()) > 0:
           result_map[collection_id] = collection_version
-      else:
-        raise Exception([version_key.id(), collection_references[i].semver])
     raise ndb.Return(result_map.values())
 
 class Content(ndb.Model):

--- a/src/datamodel.py
+++ b/src/datamodel.py
@@ -3,8 +3,18 @@ from google.appengine.ext import ndb
 import versiontag
 
 class CollectionReference(ndb.Model):
-  version = ndb.KeyProperty(kind="Version", required=True)
   semver = ndb.StringProperty()
+
+  def collection_version_key(self):
+    (owner, repo, version) = self.key.id().split('/')
+    return ndb.Key(Library, '%s/%s' % (owner, repo), Version, version)
+
+  @staticmethod
+  def ensure(library_key, collection_version_key, semver):
+    collection_library_key = collection_version_key.parent()
+    name = '%s/%s' % (collection_library_key.id(), collection_version_key.id())
+    collection_reference = CollectionReference(id=name, parent=library_key, semver=semver)
+    collection_reference.put()
 
 class Status(object):
   error = 'error'
@@ -36,21 +46,12 @@ class Library(ndb.Model):
   participation_etag = ndb.StringProperty()
 
   contributor_count = ndb.IntegerProperty()
-  collections = ndb.StructuredProperty(CollectionReference, repeated=True)
 
   ingest_versions = ndb.BooleanProperty(default=True)
 
   status = ndb.StringProperty(default=Status.pending)
   error = ndb.StringProperty()
   updated = ndb.DateTimeProperty(auto_now=True)
-
-  @staticmethod
-  def get_or_create_list(keys):
-    libraries = ndb.get_multi(keys)
-    for i, key in enumerate(keys):
-      if libraries[i] is None:
-        libraries[i] = Library(id=key.id())
-    return libraries
 
   @staticmethod
   def maybe_create_with_kind(owner, repo, kind):
@@ -99,12 +100,24 @@ class Version(ndb.Model):
   sha = ndb.StringProperty(required=True)
   url = ndb.StringProperty()
 
-  dependencies = ndb.StringProperty(repeated=True)
-
   status = ndb.StringProperty(default=Status.pending)
   error = ndb.StringProperty()
   updated = ndb.DateTimeProperty(auto_now=True)
 
+  @staticmethod
+  @ndb.tasklet
+  def collections_for_key_async(version_key):
+    library_key = version_key.parent()
+    collection_references = yield CollectionReference.query(ancestor=library_key).fetch_async()
+    collection_version_futures = [ref.collection_version_key().get_async() for ref in collection_references]
+    result = []
+    for i, version_future in enumerate(collection_version_futures):
+      version = yield version_future
+      if version is None:
+        collection_references[i].delete_async()
+      elif versiontag.match(version_key.id(), collection_references[i].semver):
+        result.append(version)
+    raise ndb.Return(result)
 
 class Content(ndb.Model):
   content = ndb.TextProperty(required=True)

--- a/src/datamodel_test.py
+++ b/src/datamodel_test.py
@@ -64,12 +64,14 @@ class CollectionReferenceTests(TestBase):
     collection_key = ndb.Key(Library, 'collection/1')
     collection_v1 = Version(id='v1.0.0', sha='x', status=Status.ready, parent=collection_key).put()
     collection_v2 = Version(id='v2.0.0', sha='x', status=Status.ready, parent=collection_key).put()
+    collection_v3 = Version(id='v3.0.0', sha='x', status=Status.ready, parent=collection_key).put()
 
     element_key = ndb.Key(Library, 'ele/ment')
     element_v1 = Version(id='v1.0.0', sha='x', status=Status.ready, parent=element_key).put()
 
     CollectionReference.ensure(element_key, collection_v1, '^1.0.0')
     CollectionReference.ensure(element_key, collection_v2, '^1.0.0')
+    CollectionReference.ensure(element_key, collection_v3, '^2.0.0')
 
     collections = yield Version.collections_for_key_async(element_v1)
     collection_keys = [collection.key for collection in collections]

--- a/src/datamodel_test.py
+++ b/src/datamodel_test.py
@@ -46,7 +46,6 @@ class VersionCacheTests(TestBase):
 class CollectionReferenceTests(TestBase):
   @ndb.toplevel
   def test_stale_ref_is_removed(self):
-    collection_key = ndb.Key(Library, 'collection/1')
     # Stale since the collection version doesn't actually exist.
     collection_v0 = ndb.Key(Library, 'collection/1', Version, 'v0.5.0')
 

--- a/src/datamodel_test.py
+++ b/src/datamodel_test.py
@@ -1,10 +1,10 @@
-from datamodel import Library, Version, Status, VersionCache
+from datamodel import Library, Version, Status, VersionCache, CollectionReference
 
 from google.appengine.ext import ndb
 
 from test_base import TestBase
 
-class LibraryTests(TestBase):
+class VersionCacheTests(TestBase):
   def test_versions_for_key(self):
     library_key = ndb.Key(Library, 'a/b')
     Version(id='v2.0.0', sha='x', status=Status.ready, parent=library_key).put()
@@ -42,3 +42,40 @@ class LibraryTests(TestBase):
     yield VersionCache.update_async(library_key)
     versions = yield Library.versions_for_key_async(library_key)
     self.assertEqual(versions, ['v1.0.0', 'v2.0.0', 'v3.0.0', 'v6.0.0'])
+
+class CollectionReferenceTests(TestBase):
+  @ndb.toplevel
+  def test_stale_ref_is_removed(self):
+    collection_key = ndb.Key(Library, 'collection/1')
+    # Stale since the collection version doesn't actually exist.
+    collection_v0 = ndb.Key(Library, 'collection/1', Version, 'v0.5.0')
+
+    element_key = ndb.Key(Library, 'ele/ment')
+    element_v1 = Version(id='v1.0.0', sha='x', status=Status.ready, parent=element_key).put()
+
+    ref0 = CollectionReference.ensure(element_key, collection_v0, '^1.0.0')
+    collections = yield Version.collections_for_key_async(element_v1)
+    collection_keys = [collection.key for collection in collections]
+
+    self.assertIsNone(ref0.get())
+    self.assertEqual(collection_keys, [])
+
+  @ndb.toplevel
+  def test_latest_matching_collection_version_is_returned(self):
+    collection_key = ndb.Key(Library, 'collection/1')
+    collection_v1 = Version(id='v1.0.0', sha='x', status=Status.ready, parent=collection_key).put()
+    collection_v2 = Version(id='v2.0.0', sha='x', status=Status.ready, parent=collection_key).put()
+
+    element_key = ndb.Key(Library, 'ele/ment')
+    element_v1 = Version(id='v1.0.0', sha='x', status=Status.ready, parent=element_key).put()
+
+    CollectionReference.ensure(element_key, collection_v1, '^1.0.0')
+    CollectionReference.ensure(element_key, collection_v2, '^1.0.0')
+
+    collections = yield Version.collections_for_key_async(element_v1)
+    collection_keys = [collection.key for collection in collections]
+
+    # Only latest matching version of the collection should be present.
+    self.assertEqual(collection_keys, [
+        collection_v2,
+    ])

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -259,8 +259,8 @@ class IngestDependenciesTest(ManageTestBase):
     # Triggers ingestions
     tasks = self.tasks.get_filtered_tasks()
     self.assertEqual([
-      util.ingest_library_task('org', 'element-1', 'element'),
-      util.ingest_library_task('org', 'element-2', 'element'),
+        util.ingest_library_task('org', 'element-1', 'element'),
+        util.ingest_library_task('org', 'element-2', 'element'),
     ], [task.url for task in tasks])
 
     # Ensures collection references

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -1,7 +1,7 @@
 import unittest
 import webtest
 
-from datamodel import Author, Library, Version, Content, Status, VersionCache
+from datamodel import Author, Library, Version, Content, Status, VersionCache, CollectionReference
 from manage import app
 import util
 
@@ -244,6 +244,31 @@ class ManageAddTest(ManageTestBase):
     tasks = self.tasks.get_filtered_tasks()
     self.assertEqual(len(tasks), 1)
     self.assertEqual(tasks[0].url, util.ingest_version_task('org', 'repo', 'commit-sha'))
+
+class IngestDependenciesTest(ManageTestBase):
+  def test_ingest_dependencies(self):
+    collection_version_key = ndb.Key(Library, 'my/collection', Version, 'v1.0.0')
+    Content(id='bower', parent=collection_version_key, content="""{"dependencies": {
+      "a": "org/element-1#1.0.0",
+      "b": "org/element-2#1.0.0"
+    }}""").put()
+
+    response = self.app.get(util.ingest_dependencies_task('my', 'collection', 'v1.0.0'), headers={'X-AppEngine-QueueName': 'default'})
+    self.assertEqual(response.status_int, 200)
+
+    # Triggers ingestions
+    tasks = self.tasks.get_filtered_tasks()
+    self.assertEqual([
+      util.ingest_library_task('org', 'element-1', 'element'),
+      util.ingest_library_task('org', 'element-2', 'element'),
+    ], [task.url for task in tasks])
+
+    # Ensures collection references
+    ref1 = CollectionReference.get_by_id(id="my/collection/v1.0.0", parent=ndb.Key(Library, "org/element-1"))
+    self.assertIsNotNone(ref1)
+
+    ref2 = CollectionReference.get_by_id(id="my/collection/v1.0.0", parent=ndb.Key(Library, "org/element-2"))
+    self.assertIsNotNone(ref2)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
- [x] move `CollectionReference` from `Library` to standalone entity
- [x] filter collection list in metadata to only one entry per collection
- [x] write tests for:
 - [x] collection ingestion
 - [x] deleting stale collection references