### PR TITLE
Centralize github logic and handle github errors gracefully

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -292,7 +292,7 @@ class RegisterPreview(webapp2.RequestHandler):
     access_token = access_token_response['access_token']
 
     # Validate access token against repo
-    repos_response = util.github_resource('user/repos', access_token=access_token)
+    repos_response = util.github_get('user/repos', access_token=access_token)
     if repos_response.status_code != 200:
       self.response.set_status(401)
       self.response.write('Cannot access user\'s repos')
@@ -429,7 +429,7 @@ class OnDemand(webapp2.RequestHandler):
       self.response.set_status(400)
       self.response.write('Unable to understand url (%s)', url)
 
-    response = util.github_resource('repos', owner, repo, 'git/refs/' + tail)
+    response = util.github_get('repos', owner, repo, 'git/refs/' + tail)
 
     if response.status_code == 404:
       self.response.set_status(400)

--- a/src/manage.py
+++ b/src/manage.py
@@ -53,6 +53,31 @@ class RequestAborted(Exception):
   pass
 
 class RequestHandler(webapp2.RequestHandler):
+  """A specialized Request Handler that deals with erroring/aborting and committing.
+
+  Subclasses should define one of ``handle_get`` or ``handle_post`` and add logic
+  to commit any permanent changes in ``commit``.
+
+  ``commit`` will be called at the end of any request unless an exception is
+  raised.
+
+  The following exceptions are treated specially:
+  * ``util.GitHubError`` which signals that the request should be retried.
+  * ``RequestAborted`` which completes the request immediately.
+
+  Subclasses can use the ``error`` and ``abort`` functions to short-circuit a request:
+  * The ``error`` function is used to denote a permanent error.
+  * The ``abort`` function is used to denote a temporary error, indicating that the
+  request should be retried.
+
+  These functions raise the ``RequestAborted`` exception and should be typically
+  called in a ``return self.error()`` style.
+
+  Subclasses should override and re-delegate the ``error`` and ``abort``
+  functions when they need to store additional information about the state. eg.
+  Stashing a permanent error in a datastore entity.
+  """
+
   def commit(self):
     pass
 

--- a/src/manage.py
+++ b/src/manage.py
@@ -139,7 +139,7 @@ class LibraryTask(RequestHandler):
       self.library.put()
 
   def update_metadata(self):
-    response = util.github_resource('repos', self.owner, self.repo, etag=self.library.metadata_etag)
+    response = util.github_get('repos', self.owner, self.repo, etag=self.library.metadata_etag)
     if response.status_code == 200:
       self.library.metadata = response.content
       self.library.metadata_etag = response.headers.get('ETag', None)
@@ -151,7 +151,7 @@ class LibraryTask(RequestHandler):
     elif response.status_code != 304:
       return self.abort('could not update repo metadata (%d)' % response.status_code)
 
-    response = util.github_resource('repos', self.owner, self.repo, 'contributors', etag=self.library.contributors_etag)
+    response = util.github_get('repos', self.owner, self.repo, 'contributors', etag=self.library.contributors_etag)
     if response.status_code == 200:
       self.library.contributors = response.content
       self.library.contributors_etag = response.headers.get('ETag', None)
@@ -160,7 +160,7 @@ class LibraryTask(RequestHandler):
       return self.abort('could not update contributors (%d)' % response.status_code)
 
     if self.library.ingest_versions:
-      response = util.github_resource('repos', self.owner, self.repo, 'stats/participation ', etag=self.library.participation_etag)
+      response = util.github_get('repos', self.owner, self.repo, 'stats/participation ', etag=self.library.participation_etag)
       if response.status_code == 200:
         self.library.participation = response.content
         self.library.participation_etag = response.headers.get('ETag', None)
@@ -195,7 +195,7 @@ class LibraryTask(RequestHandler):
     if not self.library.ingest_versions:
       return
 
-    response = util.github_resource('repos', self.owner, self.repo, 'git/refs/tags', etag=self.library.tags_etag)
+    response = util.github_get('repos', self.owner, self.repo, 'git/refs/tags', etag=self.library.tags_etag)
     if response.status_code == 304:
       return
 
@@ -303,7 +303,7 @@ class AuthorTask(RequestHandler):
       self.author.put()
 
   def update_metadata(self):
-    response = util.github_resource('users', self.author.key.id(), etag=self.author.metadata_etag)
+    response = util.github_get('users', self.author.key.id(), etag=self.author.metadata_etag)
     if response.status_code == 200:
       self.author.metadata = response.content
       self.author.metadata_etag = response.headers.get('ETag', None)

--- a/src/manage.py
+++ b/src/manage.py
@@ -282,7 +282,6 @@ class IngestWebhookLibrary(LibraryTask):
       self.update_metadata()
     self.library.github_access_token = access_token
     self.library_dirty = True
-    self.commit()
 
 class AuthorTask(RequestHandler):
   def __init__(self, request, response):

--- a/src/manage.py
+++ b/src/manage.py
@@ -320,7 +320,7 @@ class IngestAuthor(AuthorTask):
   def handle_get(self, name):
     self.init_author(name, insert=True)
     if self.author.metadata is not None:
-      return error('author has already been ingested')
+      return self.error('author has already been ingested')
     self.update_metadata()
     self.author_dirty = True
     self.author.status = Status.ready
@@ -330,7 +330,7 @@ class UpdateAuthor(AuthorTask):
   def handle_get(self, name):
     self.init_author(name, insert=False)
     if self.author is None:
-      return error('author does not exist')
+      return self.error('author does not exist')
     self.update_metadata()
 
 # TODO: Rewrite to make use of RequestHandler's error/abort functions.
@@ -450,7 +450,7 @@ class IngestAnalysis(RequestHandler):
   def is_mutation(self):
     # FIXME: This is really a mutation.
     return False
-    
+
   def handle_post(self):
     message_json = json.loads(urllib.unquote(self.request.body).rstrip('='))
     message = message_json['message']

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -126,6 +126,11 @@ class ManageAddTest(ManageTestBase):
     self.assertEqual(tasks[1].url, util.ingest_version_task('org', 'repo', 'v1.0.0') + '?latestVersion=True')
     self.assertEqual(tasks[2].url, util.ingest_author_task('org'))
 
+  def github_error_fails_gracefully(self):
+    self.respond_to_github('https://api.github.com/repos/org/repo', {'status': '500'})
+    response = self.app.get(util.ingest_library_task('org', 'repo', 'v1.0.0'), headers={'X-AppEngine-QueueName': 'default'}, status=502)
+    self.assertEqual(response.status_int, 502)
+
   def test_ingest_version(self):
     library = Library(id='org/repo', metadata='{"full_name": "NSS Bob", "stargazers_count": 420, "subscribers_count": 419, "forks": 418, "updated_at": "2011-8-10T13:47:12Z"}', contributor_count=417)
     version = Version(parent=library.key, id='v1.0.0', sha='lol')

--- a/src/util.py
+++ b/src/util.py
@@ -110,7 +110,7 @@ def github_get(name, owner=None, repo=None, context=None, etag=None, access_toke
   return github_request(name, owner=owner, repo=repo, context=context, etag=etag, access_token=access_token)
 
 def github_post(name, owner=None, repo=None, context=None, payload=None, access_token=None):
-  return github_request(name, owner=owner, repo=repo, context=context, access_token=access_token, method='POST')
+  return github_request(name, owner=owner, repo=repo, context=context, access_token=access_token, method='POST', payload=payload)
 
 def github_request(name, owner=None, repo=None, context=None, etag=None, access_token=None, method='GET', payload=None):
   headers = {}
@@ -118,10 +118,10 @@ def github_request(name, owner=None, repo=None, context=None, etag=None, access_
   if etag is not None:
     headers['If-None-Match'] = etag
   url = github_url(name, owner, repo, context)
-  response = urlfetch.fetch(url, headers=headers, validate_certificate=True, payload=payload, method=method)
+  response = urlfetch.fetch(url, headers=headers, validate_certificate=True, payload=json.dumps(payload), method=method)
   ratelimit_remaining = response.headers.get('x-ratelimit-remaining', None)
   if ratelimit_remaining is not None:
-    logging.info('GitHub ratelimit remaining %s' % ratelimit_remaining)
+    logging.info('GitHub ratelimit remaining %s', ratelimit_remaining)
   if response.status_code == 403:
     logging.warning('GitHub quota exceeded for %s %s', method, url)
     raise GitHubQuotaExceededError('reservation exceeded')

--- a/src/util.py
+++ b/src/util.py
@@ -84,16 +84,19 @@ def new_task(url, params=None, target=None):
 def inline_demo_transform(markdown):
   return re.sub(r'<!---?\n*(```(?:html)?\n<custom-element-demo.*?```)\n-->', r'\1', markdown, flags=re.DOTALL)
 
-class GithubQuotaExceededError(Exception):
+class GitHubError(Exception):
   pass
 
-class GithubServerError(Exception):
+class GitHubQuotaExceededError(GitHubError):
+  pass
+
+class GitHubServerError(GitHubError):
   pass
 
 def github_rate_limit():
   headers = {}
   add_authorization_header(headers)
-  response = urlfetch.fetch(github_url('rate_limit'), headers=headers, validate_certificate=True)
+  response = github_resource('rate_limit')
   return {
       'x-ratelimit-reset': response.headers.get('x-ratelimit-reset', 'unknown'),
       'x-ratelimit-limit': response.headers.get('x-ratelimit-limit', 'unknown'),
@@ -101,35 +104,30 @@ def github_rate_limit():
   }
 
 def github_markdown(content):
-  headers = {}
-  add_authorization_header(headers)
-  response = urlfetch.fetch(github_url('markdown'), method='POST', validate_certificate=True, headers=headers,
-                            payload=json.dumps({'text': inline_demo_transform(content)}))
-  if response.status_code == 403:
-    raise GithubQuotaExceededError('reservation exceeded')
-  elif response.status_code >= 500:
-    raise GithubServerError(response.status_code)
-  return response
+  return github_post('markdown', payload={'text': inline_demo_transform(content)})
 
+# TODO: Rename to github_get
 def github_resource(name, owner=None, repo=None, context=None, etag=None, access_token=None):
+  return github_request(name, owner=owner, repo=repo, context=context, etag=etag, access_token=access_token)
+
+def github_post(name, owner=None, repo=None, context=None, payload=None, access_token=None):
+  return github_request(name, owner=owner, repo=repo, context=context, access_token=access_token, method='POST')
+
+def github_request(name, owner=None, repo=None, context=None, etag=None, access_token=None, method='GET', payload=None):
   headers = {}
   add_authorization_header(headers, access_token)
   if etag is not None:
     headers['If-None-Match'] = etag
-  response = urlfetch.fetch(github_url(name, owner, repo, context), headers=headers, validate_certificate=True)
-  if response.status_code == 403:
-    raise GithubQuotaExceededError('reservation exceeded')
-  elif response.status_code >= 500:
-    raise GithubServerError(response.status_code)
-  return response
-
-def github_post(name, owner, repo, context=None, payload=None, access_token=None):
-  headers = {}
-  add_authorization_header(headers, access_token)
   url = github_url(name, owner, repo, context)
-  response = urlfetch.fetch(url, payload=json.dumps(payload), headers=headers, validate_certificate=True, method='POST')
+  response = urlfetch.fetch(url, headers=headers, validate_certificate=True, payload=payload, method=method)
+  ratelimit_remaining = response.headers.get('x-ratelimit-remaining', None)
+  if ratelimit_remaining is not None:
+    logging.info('GitHub ratelimit remaining %s' % ratelimit_remaining)
   if response.status_code == 403:
-    raise GithubQuotaExceededError('reservation exceeded')
+    logging.warning('GitHub quota exceeded for %s %s', method, url)
+    raise GitHubQuotaExceededError('reservation exceeded')
   elif response.status_code >= 500:
-    raise GithubServerError(response.status_code)
+    logging.error('GitHub returned unexpected response for %s %s', method, url)
+    raise GitHubServerError(response.status_code)
+  logging.info('GitHub %s %s %d', method, url, response.status_code)
   return response

--- a/src/util.py
+++ b/src/util.py
@@ -96,7 +96,7 @@ class GitHubServerError(GitHubError):
 def github_rate_limit():
   headers = {}
   add_authorization_header(headers)
-  response = github_resource('rate_limit')
+  response = github_get('rate_limit')
   return {
       'x-ratelimit-reset': response.headers.get('x-ratelimit-reset', 'unknown'),
       'x-ratelimit-limit': response.headers.get('x-ratelimit-limit', 'unknown'),
@@ -106,8 +106,7 @@ def github_rate_limit():
 def github_markdown(content):
   return github_post('markdown', payload={'text': inline_demo_transform(content)})
 
-# TODO: Rename to github_get
-def github_resource(name, owner=None, repo=None, context=None, etag=None, access_token=None):
+def github_get(name, owner=None, repo=None, context=None, etag=None, access_token=None):
   return github_request(name, owner=owner, repo=repo, context=context, etag=etag, access_token=access_token)
 
 def github_post(name, owner=None, repo=None, context=None, payload=None, access_token=None):


### PR DESCRIPTION
This ensures that we're using the same pattern throughout manage -- github server errors bubble up to the top of the request handler where they're converted into a `502` causing the task to be retried.