### PR TITLE
Create a cache of ingested versions for each library

### DIFF
--- a/src/datamodel.py
+++ b/src/datamodel.py
@@ -65,7 +65,9 @@ class Library(ndb.Model):
   @ndb.tasklet
   def versions_for_key_async(key):
     version_cache = yield VersionCache.get_by_id_async('versions', parent=key)
-    versions = [] if version_cache is None else version_cache.versions
+    versions = []
+    if version_cache is not None:
+      versions = version_cache.versions
     raise ndb.Return(versions)
 
   @staticmethod

--- a/src/datamodel.py
+++ b/src/datamodel.py
@@ -82,7 +82,7 @@ class VersionCache(ndb.Model):
   @staticmethod
   @ndb.tasklet
   @ndb.transactional
-  def update(library_key, create=False):
+  def update_async(library_key, create=False):
     versions = yield Library.uncached_versions_for_key_async(library_key)
     if create:
       version_cache = yield VersionCache.get_or_insert_async('versions', parent=library_key, versions=versions)
@@ -91,6 +91,7 @@ class VersionCache(ndb.Model):
     if version_cache is not None and version_cache.versions != versions:
       version_cache.versions = versions
       version_cache.put()
+    raise ndb.Return(None)
 
 class Version(ndb.Model):
   sha = ndb.StringProperty(required=True)

--- a/src/datamodel_test.py
+++ b/src/datamodel_test.py
@@ -1,4 +1,4 @@
-from datamodel import Library, Version
+from datamodel import Library, Version, Status, VersionCache
 
 from google.appengine.ext import ndb
 
@@ -7,11 +7,38 @@ from test_base import TestBase
 class LibraryTests(TestBase):
   def test_versions_for_key(self):
     library_key = ndb.Key(Library, 'a/b')
-    Version(id='v2.0.0', sha='x', parent=library_key).put()
-    Version(id='v1.0.0', sha='x', parent=library_key).put()
-    Version(id='v3.0.0', sha='x', parent=library_key).put()
-    Version(id='v3.0.X', sha='x', parent=library_key).put()
-    Version(id='xxx', sha='x', parent=library_key).put()
-    versions = Library.versions_for_key_async(library_key).get_result()
+    Version(id='v2.0.0', sha='x', status=Status.ready, parent=library_key).put()
+    Version(id='v1.0.0', sha='x', status=Status.ready, parent=library_key).put()
+    Version(id='v3.0.0', sha='x', status=Status.ready, parent=library_key).put()
+    Version(id='v3.0.X', sha='x', status=Status.ready, parent=library_key).put()
+    Version(id='v4.0.0', sha='x', status=Status.error, parent=library_key).put()
+    Version(id='v5.0.0', sha='x', status=Status.pending, parent=library_key).put()
+    Version(id='xxx', sha='x', status=Status.ready, parent=library_key).put()
+    versions = yield Library.uncached_versions_for_key_async(library_key)
     self.assertEqual(versions, ['v1.0.0', 'v2.0.0', 'v3.0.0'])
 
+  @ndb.toplevel
+  def test_version_cache(self):
+    library_key = ndb.Key(Library, 'a/b')
+    Version(id='v2.0.0', sha='x', status=Status.ready, parent=library_key).put()
+    Version(id='v1.0.0', sha='x', status=Status.ready, parent=library_key).put()
+    Version(id='v3.0.0', sha='x', status=Status.ready, parent=library_key).put()
+    Version(id='v3.0.X', sha='x', status=Status.ready, parent=library_key).put()
+    Version(id='v4.0.0', sha='x', status=Status.error, parent=library_key).put()
+    Version(id='v5.0.0', sha='x', status=Status.pending, parent=library_key).put()
+    Version(id='xxx', sha='x', status=Status.ready, parent=library_key).put()
+    versions = yield Library.versions_for_key_async(library_key)
+    self.assertEqual(versions, [])
+
+    yield VersionCache.update_async(library_key)
+    versions = yield Library.versions_for_key_async(library_key)
+    self.assertEqual(versions, [])
+
+    yield VersionCache.update_async(library_key, create=True)
+    versions = yield Library.versions_for_key_async(library_key)
+    self.assertEqual(versions, ['v1.0.0', 'v2.0.0', 'v3.0.0'])
+
+    Version(id='v6.0.0', sha='x', status=Status.ready, parent=library_key).put()
+    yield VersionCache.update_async(library_key)
+    versions = yield Library.versions_for_key_async(library_key)
+    self.assertEqual(versions, ['v1.0.0', 'v2.0.0', 'v3.0.0', 'v6.0.0'])

--- a/src/manage.py
+++ b/src/manage.py
@@ -365,7 +365,7 @@ class IngestVersion(RequestHandler):
     self.owner = None
     self.repo = None
     self.version = None
-    self.generate_search = False
+    self.latest_version = False
 
   @ndb.toplevel
   def handle_get(self, owner, repo, version):

--- a/src/manage.py
+++ b/src/manage.py
@@ -14,7 +14,7 @@ import urllib
 import webapp2
 import sys
 
-from datamodel import Author, Status, Library, Version, Content, CollectionReference, Dependency
+from datamodel import Author, Status, Library, Version, Content, CollectionReference, Dependency, VersionCache
 import versiontag
 import util
 
@@ -367,6 +367,7 @@ class IngestVersion(RequestHandler):
     self.version = None
     self.generate_search = False
 
+  @ndb.toplevel
   def handle_get(self, owner, repo, version):
     self.owner = owner
     self.repo = repo
@@ -387,6 +388,7 @@ class IngestVersion(RequestHandler):
       self.index_for_search(bower)
 
     self.set_ready()
+    VersionCache.update(self.version_key.parent())
     # FIXME: build version map
 
   def commit(self):

--- a/src/manage.py
+++ b/src/manage.py
@@ -395,7 +395,7 @@ class IngestVersion(RequestHandler):
 
       # Update the version cache if it exists.
       # Create it if we're ingesting the latest version.
-      VersionCache.update(self.version_key.parent(), create=self.latest_version)
+      VersionCache.update_async(self.version_key.parent(), create=self.latest_version).get_result()
 
   def error(self, error_string):
     self.version_object.status = Status.error


### PR DESCRIPTION
During the first ingestion, we won't yield any versions until the latest version is successfully ingested.