### PR TITLE
Rework library ingestion and indexing

### DIFF
--- a/src/datamodel.py
+++ b/src/datamodel.py
@@ -61,6 +61,10 @@ class Library(ndb.Model):
   updated = ndb.DateTimeProperty(auto_now=True)
 
   @staticmethod
+  def id(owner, repo):
+    return '%s/%s' % (owner.lower(), repo.lower())
+
+  @staticmethod
   def maybe_create_with_kind(owner, repo, kind):
     library = Library.get_or_insert('%s/%s' % (owner, repo))
     # FIXME: Probably don't want libraries to change kind.
@@ -77,6 +81,14 @@ class Library(ndb.Model):
     if version_cache is not None:
       versions = version_cache.versions
     raise ndb.Return(versions)
+
+  @staticmethod
+  @ndb.tasklet
+  def latest_version_for_key_async(key):
+    versions = yield Library.versions_for_key_async(key)
+    if versions == []:
+      raise ndb.Return(None)
+    raise ndb.Return(versions[-1])
 
   @staticmethod
   def uncached_versions_for_key(key):

--- a/src/datamodel.py
+++ b/src/datamodel.py
@@ -79,29 +79,30 @@ class Library(ndb.Model):
     raise ndb.Return(versions)
 
   @staticmethod
-  @ndb.tasklet
-  def uncached_versions_for_key_async(key):
-    versions = yield Version.query(Version.status == Status.ready, ancestor=key).fetch_async(keys_only=True)
+  def uncached_versions_for_key(key):
+    versions = Version.query(Version.status == Status.ready, ancestor=key).fetch(keys_only=True)
     versions = [key.id() for key in versions if versiontag.is_valid(key.id())]
     versions.sort(versiontag.compare)
-    raise ndb.Return(versions)
+    return versions
 
 class VersionCache(ndb.Model):
   versions = ndb.StringProperty(repeated=True, indexed=False)
 
   @staticmethod
-  @ndb.tasklet
   @ndb.transactional
-  def update_async(library_key, create=False):
-    versions = yield Library.uncached_versions_for_key_async(library_key)
-    if create:
-      version_cache = yield VersionCache.get_or_insert_async('versions', parent=library_key, versions=versions)
-    else:
-      version_cache = yield VersionCache.get_by_id_async('versions', parent=library_key)
-    if version_cache is not None and version_cache.versions != versions:
+  def update(library_key):
+    """Returns whether the latest version has changed and an index update is needed.
+    """
+    versions = Library.uncached_versions_for_key(library_key)
+    version_cache = VersionCache.get_or_insert('versions', parent=library_key, versions=[])
+    needs_index_update = False
+    if version_cache.versions != versions:
+      old_latest = version_cache.versions[-1] if len(version_cache.versions) > 0 else None
+      new_latest = versions[-1] if len(versions) > 0 else None
+      needs_index_update = old_latest != new_latest
       version_cache.versions = versions
       version_cache.put()
-    raise ndb.Return(None)
+    return needs_index_update
 
 class Version(ndb.Model):
   sha = ndb.StringProperty(required=True)

--- a/src/datamodel.py
+++ b/src/datamodel.py
@@ -103,10 +103,11 @@ class VersionCache(ndb.Model):
   @staticmethod
   @ndb.transactional
   def update(library_key):
-    """Returns whether the latest version has changed and an index update is needed.
+    """Updates the version cache and returns whether the latest version has
+       changed and an index update is needed.
     """
     versions = Library.uncached_versions_for_key(library_key)
-    version_cache = VersionCache.get_or_insert('versions', parent=library_key, versions=[])
+    version_cache = VersionCache.get_or_insert('versions', parent=library_key)
     needs_index_update = False
     if version_cache.versions != versions:
       old_latest = version_cache.versions[-1] if len(version_cache.versions) > 0 else None

--- a/src/datamodel_test.py
+++ b/src/datamodel_test.py
@@ -30,16 +30,14 @@ class VersionCacheTests(TestBase):
     versions = yield Library.versions_for_key_async(library_key)
     self.assertEqual(versions, [])
 
-    yield VersionCache.update_async(library_key)
-    versions = yield Library.versions_for_key_async(library_key)
-    self.assertEqual(versions, [])
-
-    yield VersionCache.update_async(library_key, create=True)
+    latest_changed = VersionCache.update(library_key)
+    self.assertTrue(latest_changed)
     versions = yield Library.versions_for_key_async(library_key)
     self.assertEqual(versions, ['v1.0.0', 'v2.0.0', 'v3.0.0'])
 
     Version(id='v6.0.0', sha='x', status=Status.ready, parent=library_key).put()
-    yield VersionCache.update_async(library_key)
+    latest_changed = VersionCache.update(library_key)
+    self.assertTrue(latest_changed)
     versions = yield Library.versions_for_key_async(library_key)
     self.assertEqual(versions, ['v1.0.0', 'v2.0.0', 'v3.0.0', 'v6.0.0'])
 

--- a/src/manage.py
+++ b/src/manage.py
@@ -235,7 +235,7 @@ class LibraryTask(RequestHandler):
 
   def trigger_version_deletion(self, tag):
     task_url = util.delete_task(self.owner, self.repo, tag)
-    util.new_task(task_url, target='manage')
+    util.new_task(task_url, target='manage', transactional=True)
 
   def trigger_version_ingestion(self, tag, sha, url=None):
     version_object = Version.get_by_id(tag, parent=self.library.key)
@@ -251,14 +251,14 @@ class LibraryTask(RequestHandler):
       params['url'] = url
 
     task_url = util.ingest_version_task(self.owner, self.repo, tag)
-    util.new_task(task_url, params=params, target='manage')
+    util.new_task(task_url, params=params, target='manage', transactional=True)
     util.publish_analysis_request(self.owner, self.repo, tag)
 
   def trigger_author_ingestion(self):
     if self.library.shallow_ingestion:
       return
     task_url = util.ingest_author_task(self.owner)
-    util.new_task(task_url, target='manage')
+    util.new_task(task_url, target='manage', transactional=True)
 
   def ingest_versions(self):
     if self.library.shallow_ingestion:

--- a/src/manage.py
+++ b/src/manage.py
@@ -423,6 +423,7 @@ class UpdateAuthor(AuthorTask):
 
 class DeleteVersion(RequestHandler):
   def handle_get(self, owner, repo, version):
+    # FIXME: Make deletion transactional with check on library that tag is excluded.
     version_key = ndb.Key(Library, '%s/%s' % (owner, repo), Version, version)
     ndb.delete_multi(ndb.Query(ancestor=version_key).iter(keys_only=True))
     if VersionCache.update(version_key.parent()):

--- a/src/manage.py
+++ b/src/manage.py
@@ -434,12 +434,6 @@ class IngestVersion(RequestHandler):
     self.repo = None
     self.version = None
 
-  def is_transactional(self):
-    """ Version ingestion need not be transactional since it's always triggered
-        from library ingestion or update.
-    """
-    return False
-
   def handle_get(self, owner, repo, version):
     self.owner = owner
     self.repo = repo

--- a/src/manage.py
+++ b/src/manage.py
@@ -101,11 +101,11 @@ class RequestHandler(webapp2.RequestHandler):
         def transactional_get():
           try:
             self.handle_get(**kwargs)
-            self.commit()
           except util.GitHubError as error:
             self.abort_error = error
           except RequestAborted as error:
             self.abort_error = error
+          self.commit()
         transactional_get()
         if self.abort_error is not None:
           raise self.abort_error
@@ -118,6 +118,8 @@ class RequestHandler(webapp2.RequestHandler):
       pass
 
   def post(self, **kwargs):
+    # because it's not implemented yet...
+    assert not self.is_transactional()
     if self.is_mutation() and not validate_mutation_request(self):
       return
     try:

--- a/src/util.py
+++ b/src/util.py
@@ -58,6 +58,9 @@ def content_url(owner, repo, version, path):
 def update_author_task(name):
   return '/task/update/%s' % name
 
+def update_indexes_task(owner, repo):
+  return '/task/update-indexes/%s/%s' % (owner, repo)
+
 def ingest_author_task(name):
   return '/task/ingest/author/%s' % name
 
@@ -72,9 +75,6 @@ def ingest_webhook_task(owner, repo):
 
 def ingest_version_task(owner, repo, version):
   return '/task/ingest/version/%s/%s/%s' % (owner, repo, version)
-
-def ingest_dependencies_task(owner, repo, version):
-  return '/task/ingest/dependencies/%s/%s/%s' % (owner, repo, version)
 
 def delete_task(owner, repo, version):
   return '/task/delete/%s/%s/%s' % (owner, repo, version)

--- a/src/util.py
+++ b/src/util.py
@@ -79,10 +79,10 @@ def ingest_dependencies_task(owner, repo, version):
 def delete_task(owner, repo, version):
   return '/task/delete/%s/%s/%s' % (owner, repo, version)
 
-def new_task(url, params=None, target=None):
+def new_task(url, params=None, target=None, transactional=False):
   if params is None:
     params = {}
-  return taskqueue.add(method='GET', url=url, params=params, target=target)
+  return taskqueue.add(method='GET', url=url, params=params, target=target, transactional=transactional)
 
 def inline_demo_transform(markdown):
   return re.sub(r'<!---?\n*(```(?:html)?\n<custom-element-demo.*?```)\n-->', r'\1', markdown, flags=re.DOTALL)

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import logging
 import optparse
 import os
 import sys
@@ -34,6 +35,8 @@ def main(sdk_path):
     print "Note: unable to import appengine_config."
 
   test_path = os.path.dirname(sys.modules[__name__].__file__)
+
+  logging.disable(logging.CRITICAL)
 
   # Discover and run tests.
   suite = unittest.loader.TestLoader().discover(test_path, pattern='*_test.py')


### PR DESCRIPTION
Library ingestion is now transactional
* version ingestion tasks won't start until the library has been committed. This avoids attempting to index a version before the library has been written.

Indexing and collection references are now built in a separate task
* removes the need to thread `latest_version` through each version ingestion
* ensures that we actually index the latest version when there are multiple ingestions happening concurrently

Some other cleanups:
* added a utility to build a Library id, `Library.id`
* added a utility to find the latest version for a Library, `Library.latest_version_for_key_async`