### PR TITLE
Fix missing data issue by always forcing install so that package data is always available (with paths).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
     - client/bower_components
     - lib
     - gcloud
+    - analysis/node_modules
 env:
   global:
   - secure: hwsxx5wg82V14R7A1qX6C/EOVZl/bC91sxtcj7pODHqw8WIG5ECzms4QLkpFS+e7pEZqQ5fiF9A9AWidtXaowu/wrGMGhRrB4ZsUvnmeoql9YcKpmm9HnUY7Ers8aC2g2wbNKg7zpOqytQHt8MDtXtCmLibapMU/CMKMhvoFWF/eNcVa6RwqGvtx1NAWyLZP2rnSVYyxxupUABssRqk8zMf/Fp+RGa2tuRQajyXhI6Zj2f3+FTpzzvHtEiFLHNhPq06/BaDPzkgDuXg1J+qIUfUA42FZWUFfDJ0MSDQBai/d9oyKZO8oqfydAU4WljfjP7c26b0/5kErEwoWASJWc6/O10G8LW+7k2FiAKkGvX7LcTylATBPWkaYyxynTef/m8L8PYwLk5ENXsb1nJGxcDLLW03eHfw3LyMl5rbD83HQH+WQAZAmuQpJvJqPo+GGU2EpXWOJFgI3AM4uD6zU7B69qdMwcUwUSGq0mIf2CPeHdgw00cMoVJIK+ziedVXiBADyBpAx106mhOUxH6wCMhEmrosnA8t/TNm4B4OI0NhD+TbFCYkOX04CtJJhBuZy9izF+rIWUeORO4l3+vqX+q6kt1se/Tcp3L6FoQoraG+pFzngU4e3birx/VRfdaaC6eLebyJNw+EErGutq7/40GnEC84l8xmlXZZ4UmPWddU=
@@ -26,6 +27,7 @@ install:
 - npm install -g bower
 - npm install
 - "(cd client; bower install)"
+- "(cd analysis; npm install)"
 - pip install -r requirements.txt -t lib/
 - if [ ! -d $HOME/gcloud/google-cloud-sdk ]; then mkdir -p $HOME/gcloud && wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz
   --directory-prefix=$HOME/gcloud && cd $HOME/gcloud && tar xzf google-cloud-sdk.tar.gz
@@ -36,6 +38,7 @@ script:
 - grunt lint
 - python tests.py $HOME/gcloud/google-cloud-sdk
 - xvfb-run wct --skip-plugin sauce
+- "(cd analysis; npm test)"
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct; fi
 before_deploy:
 - openssl aes-256-cbc -K $encrypted_ab98d8519375_key -iv $encrypted_ab98d8519375_iv

--- a/analysis/package.json
+++ b/analysis/package.json
@@ -18,6 +18,7 @@
     "test-mocha": "mocha -R spec ./test/bower-test.js"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "mocha": "^3.0.2"
   }
 }

--- a/analysis/package.json
+++ b/analysis/package.json
@@ -13,6 +13,11 @@
     "node": "4.4.5"
   },
   "scripts": {
-    "start": "node src/main.js custom-elements-staging"
+    "start": "node src/main.js custom-elements-staging",
+    "test": "npm run test-mocha",
+    "test-mocha": "mocha -R spec ./test/bower-test.js"
+  },
+  "devDependencies": {
+    "mocha": "^3.0.2"
   }
 }

--- a/analysis/src/bower.js
+++ b/analysis/src/bower.js
@@ -24,7 +24,7 @@ class Bower {
     var packageToInstall = packageWithOwner + "#" + versionOrSha;
     Ana.log("bower/install", packageToInstall);
     return new Promise((resolve, reject) => {
-      bower.commands.install([packageToInstall]).on('end', function(installed) {
+      bower.commands.install([packageToInstall], {}, {force: true}).on('end', function(installed) {
         Ana.success("bower/install", packageToInstall);
         for (let bowerPackage in installed) {
           if (installed[bowerPackage].endpoint.source.toLowerCase() != packageWithOwner.toLowerCase()) {
@@ -48,7 +48,7 @@ class Bower {
           resolve(mainHtmls.map(mainHtml => [canonicalDir, mainHtml].join("/"))); // eslint-disable-line no-loop-func
           return;
         }
-        Ana.fail("bower/install", "Couldn't find package after installing", packageToInstall);
+        Ana.fail("bower/install", "Couldn't find package after installing [", packageToInstall, "] found [" + JSON.stringify(installed) + "]");
         reject(Error("BOWER: install: package installed not in list"));
       }).on('error', function(error) {
         Ana.fail("bower/install", packageToInstall);

--- a/analysis/src/catalog.js
+++ b/analysis/src/catalog.js
@@ -26,10 +26,12 @@ class Catalog {
    * Creates a catalog service using the given pubsub client. It will connect to
    * (or create) the specified topic and subscription.
    * @param {Object} pubsub - The pubsub client.
+   * @param {bool} debug - debug mode
    */
-  constructor(pubsub) {
+  constructor(pubsub, debug) {
     Ana.log("catalog/constructor");
     this.pubsub = pubsub;
+    this.debug = debug
   }
 
   /**
@@ -44,6 +46,10 @@ class Catalog {
       Ana.log("catalog/postResponse", topicName);
       // omit ridiculously huge (or circular) fields from JSON stringify
       removeProperties(data, ["scriptElement", "javascriptNode"]);
+      if (this.debug) {
+        Ana.log("catalog/postResponse/debug attributes ", attributes);
+        Ana.log("catalog/postResponse/debug data ", data);
+      }
       this.pubsub.topic(topicName).publish({
         data: data,
         attributes: attributes

--- a/analysis/src/main.js
+++ b/analysis/src/main.js
@@ -21,18 +21,20 @@ const jsonBodyParser = bodyParser.json();
 function processTasks() {
 
   var project = process.env.GAE_LONG_APP_ID;
+  var debug = false;
 
   // If NODE_ENV isn't set, we're probably not running in GAE,
   // so override the project with whatever the command line says.
   if (!process.env.NODE_ENV && process.argv.length == 3) {
     project = process.argv[2];
+    debug = true;
   }
 
   Ana.log("main/processTasks", "Using project [", project, "]");
   var analysis = new Analysis(
       new Bower(),
       new Hydrolysis(),
-      new Catalog(pubsub({projectId: project})));
+      new Catalog(pubsub({projectId: project}), debug));
 
   app.post('/process/next', jsonBodyParser, (req, res) => {
     var message = req.body.message;

--- a/analysis/test/bower-test.js
+++ b/analysis/test/bower-test.js
@@ -3,18 +3,15 @@ var expect = require('chai').expect;
 
 var Bower = require('../src/bower');
 
-describe("Bower", function() {
-	describe("Multiple installs", function() {
-		it("returns the same data", function() {
-      this.timeout(15000);
-      var bower = new Bower();
-      return bower.install("PolymerElements", "paper-radio-button", "v1.2.1")
-          .then(function(data) {
-            bower.install("PolymerElements", "paper-radio-button", "v1.2.1")
-              .then(function(secondData) {
-                expect(data).to.deep.equal(secondData);
-              });
-          });
+describe("Bower - multiple installs", function() {
+  it("returns the same data", function() {
+    this.timeout(15000);
+    var bower = new Bower();
+    return bower.install("PolymerElements", "paper-radio-button", "v1.2.1").then(function(first) {
+      bower.install("PolymerElements", "paper-radio-button", "v1.2.1").then(function(second) {
+        expect(second).to.be.not.empty();
+        expect(first).to.deep.equal(second);
+      });
     });
-	});
+  });
 });

--- a/analysis/test/bower-test.js
+++ b/analysis/test/bower-test.js
@@ -1,0 +1,20 @@
+
+var expect = require('chai').expect;
+
+var Bower = require('../src/bower');
+
+describe("Bower", function() {
+	describe("Multiple installs", function() {
+		it("returns the same data", function() {
+      this.timeout(15000);
+      var bower = new Bower();
+      return bower.install("PolymerElements", "paper-radio-button", "v1.2.1")
+          .then(function(data) {
+            bower.install("PolymerElements", "paper-radio-button", "v1.2.1")
+              .then(function(secondData) {
+                expect(data).to.deep.equal(secondData);
+              });
+          });
+    });
+	});
+});


### PR DESCRIPTION
The Bower JS API only provides certain information through certain APIs.
When I stopped purging the local bower_components (so that we could run multiple sessions concurrently), bower.install succeeded (but provided no data) whenever the package had already been installed as it hadn't done anything (my bad).
There's no API to get the path data we need except on install, so... force installing will make it always happen for us. This will use more data, but that's not really much of an issue.