### PR TITLE
Fix 'all' of the concurrency issues and make bower installation fast again.

### DIFF
--- a/analysis/analysis.yaml
+++ b/analysis/analysis.yaml
@@ -1,4 +1,5 @@
 service: analysis
 runtime: nodejs
 vm: true
-threadsafe: true
+threadsafe: false
+

--- a/analysis/analysis.yaml
+++ b/analysis/analysis.yaml
@@ -2,4 +2,7 @@ service: analysis
 runtime: nodejs
 vm: true
 threadsafe: false
-
+handlers:
+- url: /process/next
+  script: IGNORED
+  secure: always

--- a/analysis/message.json
+++ b/analysis/message.json
@@ -2,10 +2,10 @@
     "message": {
         "data": "",
         "attributes": {
-    	  "owner":"PolymerElements",
-    	  "repo":"paper-radio-button",
-    	  "version":"v1.2.1",
-    	  "responseTopic":"analysis-responses"
+          "owner":"PolymerElements",
+          "repo":"paper-dialog",
+          "version":"v1.1.0",
+          "responseTopic":"analysis-responses"
         }
     }
 }

--- a/analysis/package.json
+++ b/analysis/package.json
@@ -3,11 +3,12 @@
   "version": "1.0.1",
   "private": true,
   "dependencies": {
+    "@google-cloud/pubsub": "0.1.1",
     "body-parser": "1.14.2",
     "bower": "1.7.9",
     "express": "4.13.4",
-    "@google-cloud/pubsub": "0.1.1",
-    "hydrolysis": "1.24.1"
+    "hydrolysis": "1.24.1",
+    "lockfile": "1.0.1"
   },
   "engines": {
     "node": "4.4.5"

--- a/analysis/src/analysis.js
+++ b/analysis/src/analysis.js
@@ -42,7 +42,9 @@ class Analysis {
         return;
       }
       var versionOrSha = attributes.sha ? attributes.sha : attributes.version;
-      this.bower.install(attributes.owner, attributes.repo, versionOrSha).then(mainHtmlPaths => {
+      this.bower.prune().then(() => {
+        return this.bower.install(attributes.owner, attributes.repo, versionOrSha);
+      }).then(mainHtmlPaths => {
         return Promise.all([
           this.hydrolysis.analyze(mainHtmlPaths),
           this.bower.findDependencies(attributes.owner, attributes.repo, versionOrSha)]);

--- a/analysis/src/bower.js
+++ b/analysis/src/bower.js
@@ -74,7 +74,12 @@ class Bower {
         reject(Error("BOWER: install: package installed not in list"));
       }).on('error', function(error) {
         Ana.fail("bower/install", packageToInstall);
-        reject({retry: true, error: error});
+        var retry = true;
+        // Don't retry ECONFLICT errors ("Unable to find suitable version for...").
+        if (error.code && error.code == 'ECONFLICT') {
+          retry = false;
+        }
+        reject({retry: retry, error: error});
       });
     });
   }

--- a/analysis/src/bower.js
+++ b/analysis/src/bower.js
@@ -3,6 +3,7 @@
 const bower = require('bower');
 const childProcess = require('child_process');
 const url = require('url');
+
 const Ana = require('./ana_log');
 
 /**
@@ -10,6 +11,27 @@ const Ana = require('./ana_log');
  * Provides support for installing packages, enumerating their dependencies etc...
  */
 class Bower {
+
+ /**
+  * Clean up (rm -rf) the local Bower working area.
+  * This deletes the installs for this directory, not the Bower cache
+  * (usually stored in ~/.cache/bower).
+  * @return {Promise} A promise handling the prune operation.
+  */
+  prune() {
+    return new Promise((resolve, reject) => {
+      Ana.log("bower/prune");
+      childProcess.exec("rm -rf bower_components", function(err) {
+        if (err) {
+          Ana.fail("bower/prune");
+          reject({retry: true, error: err});
+        } else {
+          Ana.success("bower/prune");
+          resolve();
+        }
+      });
+    });
+  }
 
   /**
    * Installs the specified Bower package and analyses it for main html files in the bower.json,
@@ -24,7 +46,7 @@ class Bower {
     var packageToInstall = packageWithOwner + "#" + versionOrSha;
     Ana.log("bower/install", packageToInstall);
     return new Promise((resolve, reject) => {
-      bower.commands.install([packageToInstall], {}, {force: true}).on('end', function(installed) {
+      bower.commands.install([packageToInstall], {}, {force: false}).on('end', function(installed) {
         Ana.success("bower/install", packageToInstall);
         for (let bowerPackage in installed) {
           if (installed[bowerPackage].endpoint.source.toLowerCase() != packageWithOwner.toLowerCase()) {
@@ -52,7 +74,7 @@ class Bower {
         reject(Error("BOWER: install: package installed not in list"));
       }).on('error', function(error) {
         Ana.fail("bower/install", packageToInstall);
-        reject(Error(error));
+        reject({retry: true, error: error});
       });
     });
   }
@@ -130,7 +152,6 @@ class Bower {
         }
       ).on('end', function(info) {
         info.metadata = metadata;
-        Ana.success("bower/findDependencies/info", ownerPackageVersionString);
         resolve(info);
       }).on('error', function(error) {
         Ana.fail("bower/findDependencies/info");

--- a/analysis/src/catalog.js
+++ b/analysis/src/catalog.js
@@ -47,8 +47,8 @@ class Catalog {
       // omit ridiculously huge (or circular) fields from JSON stringify
       removeProperties(data, ["scriptElement", "javascriptNode"]);
       if (this.debug) {
-        Ana.log("catalog/postResponse/debug attributes ", attributes);
-        Ana.log("catalog/postResponse/debug data ", data);
+        Ana.log("catalog/postResponse/debug attributes ", JSON.stringify(attributes));
+        Ana.log("catalog/postResponse/debug data ", JSON.stringify(data, null, '\t'));
       }
       this.pubsub.topic(topicName).publish({
         data: data,

--- a/analysis/src/main.js
+++ b/analysis/src/main.js
@@ -10,6 +10,7 @@ const pubsub = require('@google-cloud/pubsub');
 
 const express = require('express');
 const bodyParser = require('body-parser');
+const lockfile = require('lockfile');
 
 const app = express();
 const jsonBodyParser = bodyParser.json();
@@ -36,15 +37,32 @@ function processTasks() {
       new Hydrolysis(),
       new Catalog(pubsub({projectId: project}), debug));
 
+  var locky = new Date().toString() + ".lock";
+
   app.post('/process/next', jsonBodyParser, (req, res) => {
     var message = req.body.message;
-    analysis.processNextTask(message).then(function() {
-      Ana.success("main/processTasks");
-      res.status(200).send();
-    }, function(/* error */) {
-      // We have no way of retrying failed tasks yet. Just ack the message.
-      Ana.fail("main/processTasks");
-      res.status(200).send();
+    // force single-thread, wait up to 40 seconds to acquire lock
+    lockfile.lock(locky, {wait: 40000, stale: 200000}, err => {
+      if (err) {
+        Ana.success("main/processTasks/busy/willRetry");
+        res.status(503).send();
+        return;
+      }
+
+      analysis.processNextTask(message).then(function() {
+        Ana.success("main/processTasks");
+        lockfile.unlockSync(locky, {});
+        res.status(200).send();
+      }, function(error) {
+        lockfile.unlockSync(locky, {});
+        if (error.retry) {
+          Ana.fail("main/processTasks/willRetry");
+          res.status(500).send();
+        } else {
+          Ana.fail("main/processTasks");
+          res.status(200).send();
+        }
+      });
     });
   });
 

--- a/analysis/src/main.js
+++ b/analysis/src/main.js
@@ -41,10 +41,10 @@ function processTasks() {
 
   app.post('/process/next', jsonBodyParser, (req, res) => {
     var message = req.body.message;
-    // force single-thread, wait up to 40 seconds to acquire lock
-    lockfile.lock(locky, {wait: 40000, stale: 200000}, err => {
+    // force single-thread, immediately fail
+    lockfile.lock(locky, {}, err => {
       if (err) {
-        Ana.success("main/processTasks/busy/willRetry");
+        Ana.success("main/processTasks/busy/willRetry", JSON.stringify(message.attributes));
         res.status(503).send();
         return;
       }


### PR DESCRIPTION
- turn threadsafe off in the yaml (but the toggle doesn't work, but leave it there just in case it decides to one day and also, it's good documentation).
- actually make us threadsafe by using a lockfile to ensure that only one request can go through at a time and then 503ing subsequent requests.
- restore bower prune (rm -rf bower_components), since pruning in a single-threaded environment is faster than force: true (force ignores the cache, which makes things really slow)
- add retry for bower purge and install problems
- exclude ECONFLICT (conflicting/missing dependencies) from retry on bower.install
- add better debug information